### PR TITLE
fix async issue

### DIFF
--- a/src/chatClient.ts
+++ b/src/chatClient.ts
@@ -553,6 +553,8 @@ class ChatClient {
           reject(error);
         });
     });
+
+    return this.lastGetAgentInfoPromise;
   }
 
   checkSignBroadcastResult(readableStream?: any) {
@@ -569,8 +571,9 @@ class ChatClient {
         );
         this.nesaClient
           .broadcastRegisterSession()
-          .then((result: any) => {
-            resolve(this.requestAgentInfo(result, readableStream));
+          .then(async (result: any) => {
+            await this.requestAgentInfo(result, readableStream)
+            resolve(result);
           })
           .catch((error: any) => {
             console.log("checkSignBroadcastResultError: ", error);

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -49,8 +49,14 @@ export const socket: ISocket = {
       if (this.signatureData === "") {
         handle?.onerror?.(new Error("SignatureData is null"));
       } else {
-        socket.heartbeat();
-        handle?.onopen?.();
+        socket.send({
+          message: "hello",
+          signature_message: this.signatureData,
+        }, () => {
+          console.log("websocket opened");
+          socket.heartbeat();
+          handle?.onopen?.();
+        });
       }
     };
     socket.web_socket!.onclose = (e) => {


### PR DESCRIPTION
This issue might probabilistically cause the Agent to send an inference request before validating the client's registered Session on the chain. This could lead to the Agent not finding the corresponding Session when checking the request, resulting in the error message "session is closed".
